### PR TITLE
Allow content headers to be set in PutObject

### DIFF
--- a/src/SwiftClient/Extensions/HttpContentExtensions.cs
+++ b/src/SwiftClient/Extensions/HttpContentExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+
+namespace SwiftClient.Extensions
+{
+    internal static class HttpContentExtensions
+    {
+        public static void SetHeaders(this HttpContent content, Dictionary<string, string> headers)
+        {
+            if (headers == null) return;
+            foreach (var header in headers)
+            {
+                content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+    }
+}

--- a/src/SwiftClient/Interfaces/ISwiftClient.cs
+++ b/src/SwiftClient/Interfaces/ISwiftClient.cs
@@ -21,8 +21,8 @@ namespace SwiftClient
         Task<SwiftResponse> HeadObject(string containerId, string objectId, Dictionary<string, string> headers = null, Dictionary<string, string> queryParams = null);
         Task<SwiftResponse> GetObject(string containerId, string objectId, Dictionary<string, string> headers = null, Dictionary<string, string> queryParams = null);
         Task<SwiftResponse> GetObjectRange(string containerId, string objectId, long start, long end, Dictionary<string, string> headers = null, Dictionary<string, string> queryParams = null);
-        Task<SwiftResponse> PutObject(string containerId, string objectId, byte[] data, Dictionary<string, string> headers = null, Dictionary<string, string> queryParams = null);
-        Task<SwiftResponse> PutObject(string containerId, string objectId, Stream data, Dictionary<string, string> headers = null, Dictionary<string, string> queryParams = null);
+        Task<SwiftResponse> PutObject(string containerId, string objectId, byte[] data, Dictionary<string, string> headers = null, Dictionary<string, string> contentHeaders = null, Dictionary<string, string> queryParams = null);
+        Task<SwiftResponse> PutObject(string containerId, string objectId, Stream data, Dictionary<string, string> headers = null, Dictionary<string, string> contentHeaders = null, Dictionary<string, string> queryParams = null);
         Task<SwiftResponse> PutObjectChunk(string containerId, string objectId, byte[] data, int segment, Dictionary<string, string> headers = null, Dictionary<string, string> queryParams = null);
         Task<SwiftResponse> PutManifest(string containerId, string objectId, Dictionary<string, string> headers = null, Dictionary<string, string> queryParams = null);
         Task<SwiftResponse> CopyObject(string containerFromId, string objectFromId, string containerToId, string objectToId, Dictionary<string, string> headers = null);

--- a/src/SwiftClient/SwiftClientObject.cs
+++ b/src/SwiftClient/SwiftClientObject.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Http;
-using System.Threading.Tasks;
 using System.Linq;
-using System.Text;
 using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+using SwiftClient.Extensions;
 
 namespace SwiftClient
 {
@@ -101,7 +103,7 @@ namespace SwiftClient
             });
         }
 
-        public Task<SwiftResponse> PutObject(string containerId, string objectId, Stream data, Dictionary<string, string> headers = null, Dictionary<string, string> queryParams = null)
+        public Task<SwiftResponse> PutObject(string containerId, string objectId, Stream data, Dictionary<string, string> headers = null, Dictionary<string, string> contentHeaders = null, Dictionary<string, string> queryParams = null)
         {
             return AuthorizeAndExecute(async (auth) =>
             {
@@ -114,6 +116,7 @@ namespace SwiftClient
                 try
                 {
                     request.Content = new StreamContent(data);
+                    request.Content.SetHeaders(contentHeaders);
 
                     using (var response = await _client.SendAsync(request).ConfigureAwait(false))
                     {
@@ -135,7 +138,7 @@ namespace SwiftClient
             });
         }
 
-        public Task<SwiftResponse> PutObject(string containerId, string objectId, byte[] data, Dictionary<string, string> headers = null, Dictionary<string, string> queryParams = null)
+        public Task<SwiftResponse> PutObject(string containerId, string objectId, byte[] data, Dictionary<string, string> headers = null, Dictionary<string, string> contentHeaders = null, Dictionary<string, string> queryParams = null)
         {
             return AuthorizeAndExecute(async (auth) =>
             {
@@ -148,6 +151,7 @@ namespace SwiftClient
                 try
                 {
                     request.Content = new ByteArrayContent(data);
+                    request.Content.SetHeaders(contentHeaders);
 
                     using (var response = await _client.SendAsync(request).ConfigureAwait(false))
                     {
@@ -216,7 +220,7 @@ namespace SwiftClient
         }
 
         /// <summary>
-        /// Delete object. 
+        /// Delete object.
         /// If ([filter:slo]) is configured and you want to delete SLO file including segments add {"multipart-manifest", "delete"} to queryParams
         /// </summary>
         /// <param name="containerId"></param>
@@ -249,7 +253,7 @@ namespace SwiftClient
 
         /// <summary>
         /// Delete object chunk.
-        /// Unfortunately no api support for DLO delete ([filter:dlo]). 
+        /// Unfortunately no api support for DLO delete ([filter:dlo]).
         /// Deleting the manifest file won't delete the object segments.
         /// </summary>
         /// <param name="containerId"></param>
@@ -275,7 +279,7 @@ namespace SwiftClient
         /// <summary>
         /// Bulk delete objects (option available for [filter:bulk] in proxy-server.conf)
         /// Object id can be <container_id>, <container_id>/<object_id>
-        /// Example input: 
+        /// Example input:
         /// alpha/one.txt
         /// alpha/two.txt
         /// alpha


### PR DESCRIPTION
(Required for the creation of pseudo-directories, because "Content-Type: application/directory" can't be specified as a request header)